### PR TITLE
move the other Apache modules loaded, into apache::default_mods. ensu…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,13 +27,26 @@ class webserver {
     max_memory => 128,
   }
 
-  apache::mod { [
-    'php5',
-    'rewrite',
-    'actions',
-    'headers',
-  ]:
+  # All other default modules are loaded via
+  # apache::default_mods. You can override this array
+  # in your hiera definition.
+  apache::mod { 'php5':
     package_ensure => 'present',
+  }
+
+  # Needed to ensure Include /etc/apache2/conf.d/*.conf
+  # doesn't fatally exit
+  apache::custom_config { 'placeholder':
+    content => '',
+  }
+
+  # Ensure php5.conf is loaded (Apache 2.4 seems to want
+  # to remove it otherwise - possibly a bug in
+  # puppetlabs-apache module?
+  file { '/etc/php5/mods-enabled/php5.conf':
+    ensure  => link,
+    target  => '/etc/apache2/mods-available/php5.conf',
+    require => Package['libapache2-mod-php5'],
   }
 
   $logging = hiera("logging", false)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,14 +36,14 @@ class webserver {
 
   # Needed to ensure Include /etc/apache2/conf.d/*.conf
   # doesn't fatally exit
-  apache::custom_config { 'placeholder':
-    content => '',
+  apache::custom_config { 'placeholder.conf':
+    content => '# This file intentionally left blank',
   }
 
   # Ensure php5.conf is loaded (Apache 2.4 seems to want
   # to remove it otherwise - possibly a bug in
   # puppetlabs-apache module?
-  file { '/etc/php5/mods-enabled/php5.conf':
+  file { '/etc/apache2/mods-enabled/php5.conf':
     ensure  => link,
     target  => '/etc/apache2/mods-available/php5.conf',
     require => Package['libapache2-mod-php5'],


### PR DESCRIPTION
…re a placeholder exists in /etc/apache2/conf.d/ so Include doesn't break. Ensure php5.conf is always loaded